### PR TITLE
build: switch to Soldevelo container images (Bitnami access now paid)

### DIFF
--- a/Docker-compose/Default/docker-compose.yml
+++ b/Docker-compose/Default/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
 
     kafka:
-        image: docker.io/bitnami/kafka:3.9
+        image: docker.io/soldevelo/kafka:3.9
         ports:
             - "9092:9092"
         volumes:

--- a/Docker-compose/Prod/docker-compose.yml
+++ b/Docker-compose/Prod/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
 
     kafka:
-        image: docker.io/bitnami/kafka:3.9
+        image: docker.io/soldevelo/kafka:3.9
         ports:
             - "9092:9092"
         volumes:

--- a/Docker-compose/Qa/docker-compose.yml
+++ b/Docker-compose/Qa/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
 
     kafka:
-        image: docker.io/bitnami/kafka:3.9
+        image: docker.io/soldevelo/kafka:3.9
         ports:
             - "9092:9092"
         volumes:

--- a/Kubernetes/Helm/kafka/values.yaml
+++ b/Kubernetes/Helm/kafka/values.yaml
@@ -93,8 +93,8 @@ diagnosticMode:
 ##
 image:
   registry: docker.io
-  repository: bitnami/kafka
-  tag: 3.9.0-debian-12-r4
+  repository: soldevelo/kafka
+  tag: 3.9.2-debian-12-r0
   digest: ""
   ## Specify a imagePullPolicy
   ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images

--- a/Specifications and requirements/MS before server-side service discovery/Docker-compose/Default/docker-compose.yml
+++ b/Specifications and requirements/MS before server-side service discovery/Docker-compose/Default/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
 
     kafka:
-        image: docker.io/bitnami/kafka:3.9
+        image: docker.io/soldevelo/kafka:3.9
         ports:
             - "9092:9092"
         volumes:

--- a/Specifications and requirements/MS before server-side service discovery/Docker-compose/Prod/docker-compose.yml
+++ b/Specifications and requirements/MS before server-side service discovery/Docker-compose/Prod/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
 
     kafka:
-        image: docker.io/bitnami/kafka:3.9
+        image: docker.io/soldevelo/kafka:3.9
         ports:
             - "9092:9092"
         volumes:

--- a/Specifications and requirements/MS before server-side service discovery/Docker-compose/Qa/docker-compose.yml
+++ b/Specifications and requirements/MS before server-side service discovery/Docker-compose/Qa/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
 
     kafka:
-        image: docker.io/bitnami/kafka:3.9
+        image: docker.io/soldevelo/kafka:3.9
         ports:
             - "9092:9092"
         volumes:

--- a/Specifications and requirements/MS before server-side service discovery/Kubernetes/Helm/kafka/values.yaml
+++ b/Specifications and requirements/MS before server-side service discovery/Kubernetes/Helm/kafka/values.yaml
@@ -96,8 +96,8 @@ serviceBindings:
 ##
 image:
   registry: docker.io
-  repository: bitnami/kafka
-  tag: 4.0.0-debian-12-r7
+  repository: soldevelo/kafka
+  tag: 4.0.0-debian-12-r0
   digest: ""
   ## Specify a imagePullPolicy
   ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
@@ -603,8 +603,8 @@ defaultInitContainers:
     ##
     image:
       registry: docker.io
-      repository: bitnami/kubectl
-      tag: 1.33.2-debian-12-r0
+      repository: soldevelo/kubectl
+      tag: 1.33.4-debian-12-r0
       digest: ""
       ## Specify a imagePullPolicy
       ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images


### PR DESCRIPTION
## Switch container base images to SolDevelo

Bitnami images now require a VMware Tanzu subscription (change effective **August 28, 2025**). This causes pipeline failures and added cost for teams that relied on the public registry.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides drop-in replacements - same Debian-based images, same startup scripts, same environment-variable API - built openly from [SolDevelo/containers](https://github.com/SolDevelo/containers) and tagged to match Bitnami upstream.

## Image substitutions

- `bitnami/kafka:3.9` → [`soldevelo/kafka:3.9`](https://hub.docker.com/r/soldevelo/kafka)
- `bitnami/kafka:4.0.0-debian-12-r7` → [`soldevelo/kafka:4.0.0-debian-12-r0`](https://hub.docker.com/r/soldevelo/kafka)
- `bitnami/kubectl:1.33.2-debian-12-r0` → [`soldevelo/kubectl:1.33.4-debian-12-r0`](https://hub.docker.com/r/soldevelo/kubectl)
- `bitnami/kafka:3.9.0-debian-12-r4` → [`soldevelo/kafka:3.9.2-debian-12-r0`](https://hub.docker.com/r/soldevelo/kafka)